### PR TITLE
Barnetillegg og periodisering

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/arena/felles/DatoHelper.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/arena/felles/DatoHelper.kt
@@ -1,0 +1,17 @@
+package no.nav.tiltakspenger.arena.felles
+
+import java.time.LocalDate
+import java.time.Month
+
+infix fun Int.januar(year: Int): LocalDate = LocalDate.of(year, Month.JANUARY, this)
+infix fun Int.februar(year: Int): LocalDate = LocalDate.of(year, Month.FEBRUARY, this)
+infix fun Int.mars(year: Int): LocalDate = LocalDate.of(year, Month.MARCH, this)
+infix fun Int.april(year: Int): LocalDate = LocalDate.of(year, Month.APRIL, this)
+infix fun Int.mai(year: Int): LocalDate = LocalDate.of(year, Month.MAY, this)
+infix fun Int.juni(year: Int): LocalDate = LocalDate.of(year, Month.JUNE, this)
+infix fun Int.juli(year: Int): LocalDate = LocalDate.of(year, Month.JULY, this)
+infix fun Int.august(year: Int): LocalDate = LocalDate.of(year, Month.AUGUST, this)
+infix fun Int.september(year: Int): LocalDate = LocalDate.of(year, Month.SEPTEMBER, this)
+infix fun Int.oktober(year: Int): LocalDate = LocalDate.of(year, Month.OCTOBER, this)
+infix fun Int.november(year: Int): LocalDate = LocalDate.of(year, Month.NOVEMBER, this)
+infix fun Int.desember(year: Int): LocalDate = LocalDate.of(year, Month.DECEMBER, this)

--- a/src/main/kotlin/no/nav/tiltakspenger/arena/felles/Periode.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/arena/felles/Periode.kt
@@ -94,7 +94,7 @@ class Periode(fra: LocalDate, til: LocalDate) {
     }
 
     override fun toString(): String {
-        return "Periode(range=$range)"
+        return "Periode(fra=$fra til=$til)"
     }
 
     fun inneholder(dato: LocalDate): Boolean = range.contains(dato)
@@ -111,6 +111,9 @@ class Periode(fra: LocalDate, til: LocalDate) {
         val ranges = opprinneligeRangeSet.difference(andrePeriodeRangeSet).asRanges()
         return ranges.filter { !it.canonical(domain).isEmpty }.map { it.toPeriode() }
     }
+
+    fun leggTil(annenPeriode: Periode): List<Periode> =
+        listOf(this).leggSammenMed(annenPeriode, true)
 
     fun tilDager(): List<LocalDate> {
         return fra.datesUntil(til.plusDays(1)).toList()
@@ -136,6 +139,25 @@ fun List<Periode>.leggSammen(godtaOverlapp: Boolean = true): List<Periode> {
     val rangeSet = TreeRangeSet.create<LocalDate>()
     rangeSet.addAll(this.map { it.range })
     return rangeSet.asRanges().toPerioder()
+}
+
+fun List<Periode>.leggSammenMed(periode: Periode, godtaOverlapp: Boolean = true): List<Periode> {
+    return (this + periode).leggSammen(godtaOverlapp)
+}
+
+fun List<Periode>.leggSammenMed(perioder: List<Periode>, godtaOverlapp: Boolean = true): List<Periode> {
+    return (this + perioder).leggSammen(godtaOverlapp)
+}
+
+// TODO Legg til tester
+fun List<Periode>.overlappendePerioder(other: List<Periode>): List<Periode> {
+    return this.flatMap { thisPeriode ->
+        other.map { otherPeriode ->
+            thisPeriode.overlappendePeriode(otherPeriode)
+        }
+    }
+        .filterNotNull()
+        .leggSammen(false)
 }
 
 fun List<Periode>.trekkFra(perioder: List<Periode>): List<Periode> {

--- a/src/main/kotlin/no/nav/tiltakspenger/arena/felles/PeriodeMedVerdi.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/arena/felles/PeriodeMedVerdi.kt
@@ -1,0 +1,25 @@
+package no.nav.tiltakspenger.arena.felles
+
+/*
+Denne klassen representerer en sammenhengende periode som har samme verdi for hele perioden.
+Perioden kan ikke ha "hull" som ikke har en verdi
+ */
+data class PeriodeMedVerdi<T>(
+    val verdi: T,
+    val periode: Periode,
+)
+
+fun <T> List<PeriodeMedVerdi<T>>.allePerioderHarSammeVerdi() =
+    this.map { it.verdi }.distinct().size <= 1
+
+fun <T> List<PeriodeMedVerdi<T>>.perioderMedSammeVerdi(verdi: T): List<PeriodeMedVerdi<T>> =
+    this.filter { it.verdi == verdi }
+
+fun <T> List<PeriodeMedVerdi<T>>.perioderMedUlikVerdi(verdi: T): List<PeriodeMedVerdi<T>> =
+    this.filter { it.verdi != verdi }
+
+fun <T> List<PeriodeMedVerdi<T>>.trekkFra(periode: Periode): List<PeriodeMedVerdi<T>> =
+    this.flatMap {
+        it.periode.trekkFra(listOf(periode))
+            .map { nyPeriode -> PeriodeMedVerdi(it.verdi, nyPeriode) }
+    }

--- a/src/main/kotlin/no/nav/tiltakspenger/arena/felles/PeriodeMedVerdier.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/arena/felles/PeriodeMedVerdier.kt
@@ -1,0 +1,132 @@
+package no.nav.tiltakspenger.arena.felles
+
+/*
+Denne klassen representerer en sammenhengende periode som kan ha ulike verdier for ulike deler av perioden.
+Perioden kan ikke ha "hull" som ikke har en verdi
+ */
+data class PeriodeMedVerdier<T> private constructor(
+    private val totalePeriode: Periode,
+    private val defaultVerdi: T,
+    private val perioderMedVerdi: List<PeriodeMedVerdi<T>>,
+) {
+    companion object {
+        operator fun <T> invoke(
+            defaultVerdi: T,
+            totalePeriode: Periode,
+        ): PeriodeMedVerdier<T> {
+            return PeriodeMedVerdier(
+                totalePeriode = totalePeriode,
+                defaultVerdi = defaultVerdi,
+                perioderMedVerdi =
+                listOf(PeriodeMedVerdi(defaultVerdi, totalePeriode)),
+            )
+        }
+
+        fun <T> kombinerLikePerioderMedSammeTypeVerdier(
+            liste: List<PeriodeMedVerdier<T>>,
+            sammensattVerdi: (T, T) -> T,
+        ): PeriodeMedVerdier<T> {
+            return liste.reduce { total, next ->
+                total.kombiner(next, sammensattVerdi).slåSammenTilstøtendePerioder()
+            }
+        }
+    }
+
+    // Offentlig API:
+
+    fun slåSammenTilstøtendePerioder(): PeriodeMedVerdier<T> =
+        this.copy(perioderMedVerdi = perioderMedVerdi.slåSammenTilstøtendePerioder())
+
+    fun setVerdiForDelPeriode(
+        verdi: T,
+        delPeriode: Periode,
+    ): PeriodeMedVerdier<T> = setPeriodeMedVerdi(PeriodeMedVerdi(verdi, delPeriode))
+
+    fun <U, V> kombiner(
+        other: PeriodeMedVerdier<U>,
+        sammensattVerdi: (T, U) -> V,
+    ): PeriodeMedVerdier<V> {
+        if (totalePeriode != other.totalePeriode) {
+            throw IllegalArgumentException("Perioder som skal kombineres må være like")
+        }
+
+        return this.perioderMedVerdi.flatMap { thisPeriodeMedVerdi ->
+            other.perioderMedVerdi.mapNotNull { otherPeriodeMedVerdi ->
+                thisPeriodeMedVerdi.periode.overlappendePeriode(otherPeriodeMedVerdi.periode)?.let {
+                    PeriodeMedVerdi(sammensattVerdi(thisPeriodeMedVerdi.verdi, otherPeriodeMedVerdi.verdi), it)
+                }
+            }
+        }.let {
+            PeriodeMedVerdier(
+                this.totalePeriode,
+                sammensattVerdi(this.defaultVerdi, other.defaultVerdi),
+                it,
+            )
+        }
+    }
+
+    fun <U> splitt(
+        ekstrahertVerdi: (T) -> U,
+    ): PeriodeMedVerdier<U> =
+        this.perioderMedVerdi
+            .map { PeriodeMedVerdi(ekstrahertVerdi(it.verdi), it.periode) }
+            .slåSammenTilstøtendePerioder()
+            .let { PeriodeMedVerdier(this.totalePeriode, ekstrahertVerdi(this.defaultVerdi), it) }
+
+    fun perioder(): List<PeriodeMedVerdi<T>> = perioderMedVerdi.sortedBy { it.periode.fra }
+
+    // Private hjelpemetoder:
+
+    private fun setPeriodeMedVerdi(delPeriodeMedVerdi: PeriodeMedVerdi<T>): PeriodeMedVerdier<T> {
+        if (!totalePeriode.inneholderHele(delPeriodeMedVerdi.periode)) {
+            throw IllegalArgumentException("Angitt periode er ikke innenfor $totalePeriode")
+        }
+        val nyePerioderMedSammeVerdi = perioderMedVerdi
+            .perioderMedSammeVerdi(delPeriodeMedVerdi.verdi)
+            .leggTilPeriodeMedSammeVerdi(delPeriodeMedVerdi)
+        val nyePerioderMedUlikVerdi = perioderMedVerdi
+            .perioderMedUlikVerdi(delPeriodeMedVerdi.verdi)
+            .trekkFra(delPeriodeMedVerdi)
+        return PeriodeMedVerdier(
+            totalePeriode,
+            defaultVerdi,
+            nyePerioderMedSammeVerdi + nyePerioderMedUlikVerdi,
+        )
+    }
+
+    // Krever IKKE at alle elementer i lista har samme verdi for å fungere
+    private fun <T> List<PeriodeMedVerdi<T>>.trekkFra(periodeMedVerdi: PeriodeMedVerdi<T>): List<PeriodeMedVerdi<T>> =
+        this.trekkFra(periodeMedVerdi.periode)
+
+    // Krever at alle elementer i lista har samme verdi for å fungere!
+    private fun <T> List<PeriodeMedVerdi<T>>.leggSammenPerioderMedSammeVerdi(godtaOverlapp: Boolean = true): List<PeriodeMedVerdi<T>> {
+        if (!this.allePerioderHarSammeVerdi()) {
+            throw IllegalArgumentException("Kan bare legge sammen perioder med samme verdi")
+        }
+        if (!godtaOverlapp && this.map { it.periode }.inneholderOverlapp()) {
+            throw IllegalArgumentException("Listen inneholder overlappende perioder")
+        }
+        val verdi: T = this.firstOrNull()!!.verdi
+        return this.map { it.periode }.leggSammen(false).map { PeriodeMedVerdi(verdi, it) }
+    }
+
+    // Krever at alle elementer i lista har samme verdi for å fungere!
+    private fun <T> List<PeriodeMedVerdi<T>>.slåSammenTilstøtendePerioderMedSammeVerdi(): List<PeriodeMedVerdi<T>> =
+        this.leggSammenPerioderMedSammeVerdi(false)
+
+    // Krever IKKE at alle elementer i lista har samme verdi for å fungere
+    private fun <T> List<PeriodeMedVerdi<T>>.slåSammenTilstøtendePerioder(): List<PeriodeMedVerdi<T>> =
+        this.groupBy { it.verdi }
+            .values
+            .flatMap { listeMedLikeVerdier -> listeMedLikeVerdier.slåSammenTilstøtendePerioderMedSammeVerdi() }
+
+    // Krever at alle elementer i lista har samme verdi for å fungere!
+    private fun <T> List<PeriodeMedVerdi<T>>.leggTilPeriodeMedSammeVerdi(periodeMedVerdi: PeriodeMedVerdi<T>): List<PeriodeMedVerdi<T>> =
+        (this + periodeMedVerdi).leggSammenPerioderMedSammeVerdi(true)
+
+    override fun toString(): String {
+        return "PeriodeMedVerdier(totalePeriode=$totalePeriode, defaultVerdi=$defaultVerdi, perioderMedVerdi=${
+            perioderMedVerdi.sortedBy { it.periode.fra }.map { "\n" + it.toString() }
+        })"
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/arena/felles/PeriodeMedVerdier.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/arena/felles/PeriodeMedVerdier.kt
@@ -5,7 +5,7 @@ Denne klassen representerer en sammenhengende periode som kan ha ulike verdier f
 Perioden kan ikke ha "hull" som ikke har en verdi
  */
 data class PeriodeMedVerdier<T> private constructor(
-    private val totalePeriode: Periode,
+    val totalePeriode: Periode,
     private val defaultVerdi: T,
     private val perioderMedVerdi: List<PeriodeMedVerdi<T>>,
 ) {

--- a/src/main/kotlin/no/nav/tiltakspenger/arena/repository/ArenaBarnetilleggVedtakDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/arena/repository/ArenaBarnetilleggVedtakDTO.kt
@@ -1,9 +1,11 @@
 package no.nav.tiltakspenger.arena.repository
 
+import no.nav.tiltakspenger.arena.felles.Periode
 import java.time.LocalDate
 import java.time.LocalDateTime
 
-data class ArenaVedtakDTO(
+// Har ikke lagt til alle vedtaksfakta her ennå
+data class ArenaBarnetilleggVedtakDTO(
     val vedtakType: ArenaVedtakType,
     val uttaksgrad: Int,
     val fomVedtaksperiode: LocalDate,
@@ -21,8 +23,8 @@ data class ArenaVedtakDTO(
     val relatertTiltak: String?,
     val antallBarn: Int?,
 ) {
-    fun fomGyldighetsdato(): LocalDateTime? = fomVedtaksperiode.atStartOfDay()
-    fun tomGyldighetsdato(): LocalDateTime? = tomVedtaksperiode?.atStartOfDay()
+    fun fomGyldighetstidspunkt(): LocalDateTime = fomVedtaksperiode.atStartOfDay()
+    fun tomGyldighetstidspunkt(): LocalDateTime? = tomVedtaksperiode?.atStartOfDay()
 
     fun isTiltakspenger(): Boolean = this.rettighettype == ArenaRettighet.BASI
     fun isIverksatt(): Boolean = this.status == ArenaVedtakStatus.IVERK
@@ -31,6 +33,8 @@ data class ArenaVedtakDTO(
         this.vedtakType == ArenaVedtakType.O ||
             this.vedtakType == ArenaVedtakType.G ||
             this.vedtakType == ArenaVedtakType.E
+
+    fun vedtaksperiode(): Periode = Periode(fomVedtaksperiode, tomVedtaksperiode ?: LocalDate.MAX)
 
     fun isVedtaksperiodeÅpen(): Boolean = this.tomVedtaksperiode == null
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/arena/repository/ArenaTiltakspengerVedtakDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/arena/repository/ArenaTiltakspengerVedtakDTO.kt
@@ -1,0 +1,39 @@
+package no.nav.tiltakspenger.arena.repository
+
+import no.nav.tiltakspenger.arena.felles.Periode
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+// Har ikke lagt til alle vedtaksfakta her ennå
+data class ArenaTiltakspengerVedtakDTO(
+    val vedtakType: ArenaVedtakType,
+    val uttaksgrad: Int,
+    val fomVedtaksperiode: LocalDate,
+    val tomVedtaksperiode: LocalDate?,
+    val status: ArenaVedtakStatus,
+    val rettighettype: ArenaRettighet,
+    val aktivitetsfase: ArenaAktivitetFase,
+    val dagsats: Int?,
+    val beslutningsdato: LocalDate?,
+    val mottattDato: LocalDate,
+    val registrertDato: LocalDate?,
+    val utfall: ArenaUtfall,
+    val antallDager: Double?,
+    val opprinneligTomVedtaksperiode: LocalDate?,
+    val relatertTiltak: String?,
+) {
+    fun fomGyldighetstidspunkt(): LocalDateTime = fomVedtaksperiode.atStartOfDay()
+    fun tomGyldighetstidspunkt(): LocalDateTime? = tomVedtaksperiode?.atStartOfDay()
+
+    fun isTiltakspenger(): Boolean = this.rettighettype == ArenaRettighet.BASI
+    fun isIverksatt(): Boolean = this.status == ArenaVedtakStatus.IVERK
+    fun isNotAvbruttOrNei(): Boolean = !(this.utfall == ArenaUtfall.AVBRUTT || this.utfall == ArenaUtfall.NEI)
+    fun isNyRettighetOrGjenopptakOrEndring(): Boolean =
+        this.vedtakType == ArenaVedtakType.O ||
+            this.vedtakType == ArenaVedtakType.G ||
+            this.vedtakType == ArenaVedtakType.E
+
+    fun vedtaksperiode(): Periode = Periode(fomVedtaksperiode, tomVedtaksperiode ?: LocalDate.MAX)
+
+    fun isVedtaksperiodeÅpen(): Boolean = this.tomVedtaksperiode == null
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/arena/repository/ArenaVedtakfaktaDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/arena/repository/ArenaVedtakfaktaDTO.kt
@@ -7,43 +7,84 @@ import java.time.format.DateTimeFormatter
 /*
 For tiltakspenger finnes de følgende vedtakfakta:
 
-BARNMSTON	Antall barn med stønad
-DAGS	DAGSATS
-DAGUTBTILT	Antall dager med utbetaling
-FDATO	Gjelder fra
-INNVF	VEDTAKSDATO
-KODETILTAK	Relatert tiltak
-MASKVEDTAK	Maskinelt vedtak
-OPPRTDATO	Opprinnelig til-dato
-SATSKODE	Valgt sats
-TDATO	Gjelder til
-TILTAKNAVN	Knyttet til tiltak
+DAGS	    DAGSATS     	                DAGSATS	                                                                    NUMBER
+SATSKODE	Valgt sats	                    Valgt sats
+TILTAKNAVN	Knyttet til tiltak	            Knyttet til tiltak	                                                        VARCHAR2
+MASKVEDTAK	Maskinelt vedtak	            (co-am 23.01.2003) Maskinelt vedtak	                                        VARCHAR2
+OPPRTDATO	Opprinnelig til-dato	        Opprinnelig til-dato	                                                    DATE
+TDATO	    Gjelder til	                    Gjelder til. VF_4_VEDTAK_116, VF_3_VEDTAK_TIL_BREV,	                        DATE
+DAGUTBTILT	Antall dager med utbetaling	    Antall dager i løpet av en meldekortperiode det skal utbetales ytelser	    INTEGER
+FDATO	    Gjelder fra	                    Gjelder fra. VF_4_VEDTAK_116,VF_3_VEDTAK_TIL_BREV	                        DATE
+INNVF	    VEDTAKSDATO	                    VEDTAKSDATO	                                                                DATE
+KODETILTAK  Relatert tiltak	                Kode for knytting av tiltak til vedtaket	                                VARCHAR2
 
-(Hentet ut med SQLen
+Hvis jeg ikke trekker inn sak i spørringen får jeg disse - TODO å finne ut hvorfor det er ulikt antall..
+OPPRTDATO	Opprinnelig til-dato
+TILTAKNAVN	Knyttet til tiltak
+VEDTYPKONT	Vedtakstype som kontrolleres
+DAGS	DAGSATS
+FDATO	Gjelder fra
+TDATO	Gjelder til
+DAGUTBTILT	Antall dager med utbetaling
+KODETILTAK	Relatert tiltak
+INNVF	VEDTAKSDATO
+SATSKODE	Valgt sats
+SAKTYPKONT	Sakstype som kontrolleres
+TILBBETID	Vedtak id til tilbakebetalings
+MASKVEDTAK	Maskinelt vedtak
+
+For Barnetillegg finnes de følgende:
+DAGS	        DAGSATS	                    DAGSATS	                                                                                                    NUMBER
+SATSKODE	    Valgt sats	                Valgt sats
+TILTAKNAVN	    Knyttet til tiltak	        Knyttet til tiltak	                                                                                        VARCHAR2
+BARNMSTON	    Antall barn med stønad	    (CO-LN 26092001) Brukes under dagpengeprosessen. Er en del av nøkkelen i bindingen til vedtaksaksperson.    INTEGER
+MASKVEDTAK	    Maskinelt vedtak	        (co-am 23.01.2003) Maskinelt vedtak	                                                                        VARCHAR2
+OPPRTDATO	    Opprinnelig til-dato	    Opprinnelig til-dato	                                                                                    DATE
+TDATO	        Gjelder til	                Gjelder til. VF_4_VEDTAK_116, VF_3_VEDTAK_TIL_BREV,	                                                        DATE
+DAGUTBTILT	    Antall dager med utbetaling Antall dager i løpet av en meldekortperiode det skal utbetales ytelser	                                    INTEGER
+FDATO	        Gjelder fra	Gjelder fra.    VF_4_VEDTAK_116,VF_3_VEDTAK_TIL_BREV	                                                                    DATE
+INNVF	        VEDTAKSDATO	                VEDTAKSDATO	                                                                                                DATE
+KODETILTAK	    Relatert tiltak 	        Kode for knytting av tiltak til vedtaket	                                                                VARCHAR2
+
+Hentet ut med SQLene
     select distinct(vf.vedtakfaktakode), vft.vedtakfaktanavn
     from vedtakfaktatype vft, vedtakfakta vf, vedtak v, sak s
     where vft.vedtakfaktakode = vf.vedtakfaktakode
     and vf.vedtak_id = v.vedtak_id
+    and v.rettighetkode = 'BASI';
+evt
+    select distinct(vf.vedtakfaktakode), vft.vedtakfaktanavn
+    from vedtakfaktatype vft, vedtakfakta vf, vedtak v, sak s
+    where vft.vedtakfaktakode = vf.vedtakfaktakode
+    and vf.vedtak_id = v.vedtak_id
+    and v.rettighetkode = 'BASI'
     and v.sak_id = s.sak_id
     AND s.sakskode = 'INDIV';
-)
+og
+    select distinct(vf.vedtakfaktakode), vft.vedtakfaktanavn
+    from vedtakfaktatype vft, vedtakfakta vf, vedtak v, sak s
+    where vft.vedtakfaktakode = vf.vedtakfaktakode
+    and vf.vedtak_id = v.vedtak_id
+    and v.rettighetkode = 'BTIL'
+    and v.sak_id = s.sak_id
+    AND s.sakskode = 'INDIV';
+
  */
 
 private val log = KotlinLogging.logger {}
 
-enum class ArenaLovligeVedtakFaktaForTiltakspenger(val navn: String) {
-    // BARNMSTON er bare i bruk på BTIL vedtak!
-    BARNMSTON("Antall barn med stønad"),
+enum class ArenaVedtakFakta(val navn: String) {
     DAGS("DAGSATS"),
+    SATSKODE("Valgt sats"),
+    TILTAKNAVN("Knyttet til tiltak"),
+    MASKVEDTAK("Maskinelt vedtak"),
+    OPPRTDATO("Opprinnelig til-dato"),
+    TDATO("Gjelder til"),
     DAGUTBTILT("Antall dager med utbetaling"),
     FDATO("Gjelder fra"),
     INNVF("VEDTAKSDATO"),
     KODETILTAK("Relatert tiltak"),
-    MASKVEDTAK("Maskinelt vedtak"),
-    OPPRTDATO("Opprinnelig til-dato"),
-    SATSKODE("Valgt sats"),
-    TDATO("Gjelder til"),
-    TILTAKNAVN("Knyttet til tiltak"),
+    BARNMSTON(" Antall barn med stønad"), // Bare aktuell for barnetillegg
 }
 
 data class ArenaVedtakfaktaDTO(
@@ -59,8 +100,40 @@ data class ArenaTiltakspengerVedtakfaktaDTO(
     val relatertTiltak: String?,
     val relatertTiltakNavn: String?,
     val opprinneligTilDato: LocalDate?,
-    val antallBarn: Int?,
+    val gjelderFra: LocalDate?,
+    val gjelderTil: LocalDate?,
+    val satsKode: String?,
+    val maskineltVedtak: String?,
 )
+
+data class ArenaBarnetilleggVedtakfaktaDTO(
+    val beslutningsdato: LocalDate?,
+    val dagsats: Int?,
+    val antallDager: Double?,
+    val relatertTiltak: String?,
+    val relatertTiltakNavn: String?,
+    val opprinneligTilDato: LocalDate?,
+    val antallBarn: Int?,
+    val gjelderFra: LocalDate?,
+    val gjelderTil: LocalDate?,
+    val satsKode: String?,
+    val maskineltVedtak: String?,
+)
+
+fun List<ArenaVedtakfaktaDTO>.toArenaBarnetilleggVedtakfaktaDTO() =
+    ArenaBarnetilleggVedtakfaktaDTO(
+        beslutningsdato = this.beslutningsdato(),
+        dagsats = this.dagsats(),
+        antallDager = this.antallDager(),
+        relatertTiltak = this.relatertTiltak(),
+        relatertTiltakNavn = this.relatertTiltakNavn(),
+        opprinneligTilDato = this.opprinneligTilDato(),
+        antallBarn = this.antallBarn(),
+        gjelderFra = this.gjelderFra(),
+        gjelderTil = this.gjelderTil(),
+        satsKode = this.satsKode(),
+        maskineltVedtak = this.maskineltVedtak(),
+    )
 
 fun List<ArenaVedtakfaktaDTO>.toArenaTiltakspengerVedtakfaktaDTO() =
     ArenaTiltakspengerVedtakfaktaDTO(
@@ -70,39 +143,60 @@ fun List<ArenaVedtakfaktaDTO>.toArenaTiltakspengerVedtakfaktaDTO() =
         relatertTiltak = this.relatertTiltak(),
         relatertTiltakNavn = this.relatertTiltakNavn(),
         opprinneligTilDato = this.opprinneligTilDato(),
-        antallBarn = this.antallBarn(),
+        gjelderFra = this.gjelderFra(),
+        gjelderTil = this.gjelderTil(),
+        satsKode = this.satsKode(),
+        maskineltVedtak = this.maskineltVedtak(),
     )
 
 // Kan være null for tiltakspenger, selv om det kanskje er litt rart?
 private fun List<ArenaVedtakfaktaDTO>.beslutningsdato(): LocalDate? =
-    this.find { it.vedtakfaktaKode == ArenaLovligeVedtakFaktaForTiltakspenger.INNVF.name }?.vedtakfaktaVerdi
-        .also { log.info { "${ArenaLovligeVedtakFaktaForTiltakspenger.INNVF.name}: $it" } }
+    this.find { it.vedtakfaktaKode == ArenaVedtakFakta.INNVF.name }?.vedtakfaktaVerdi
+        .also { log.info { "${ArenaVedtakFakta.INNVF.name}: $it" } }
         ?.let { LocalDate.parse(it, DateTimeFormatter.ofPattern("dd-MM-yyyy")) }
 
 private fun List<ArenaVedtakfaktaDTO>.dagsats(): Int? =
-    this.find { it.vedtakfaktaKode == ArenaLovligeVedtakFaktaForTiltakspenger.DAGS.name }?.vedtakfaktaVerdi
-        .also { log.info { "${ArenaLovligeVedtakFaktaForTiltakspenger.DAGS.name}: $it" } }
+    this.find { it.vedtakfaktaKode == ArenaVedtakFakta.DAGS.name }?.vedtakfaktaVerdi
+        .also { log.info { "${ArenaVedtakFakta.DAGS.name}: $it" } }
         ?.toInt()
 
 private fun List<ArenaVedtakfaktaDTO>.antallBarn(): Int? =
-    this.find { it.vedtakfaktaKode == ArenaLovligeVedtakFaktaForTiltakspenger.BARNMSTON.name }?.vedtakfaktaVerdi
-        .also { log.info { "${ArenaLovligeVedtakFaktaForTiltakspenger.BARNMSTON.name}: $it" } }
+    this.find { it.vedtakfaktaKode == ArenaVedtakFakta.BARNMSTON.name }?.vedtakfaktaVerdi
+        .also { log.info { "${ArenaVedtakFakta.BARNMSTON.name}: $it" } }
         ?.toInt()
 
 private fun List<ArenaVedtakfaktaDTO>.antallDager(): Double? =
-    this.find { it.vedtakfaktaKode == ArenaLovligeVedtakFaktaForTiltakspenger.DAGUTBTILT.name }?.vedtakfaktaVerdi
-        .also { log.info { "${ArenaLovligeVedtakFaktaForTiltakspenger.DAGUTBTILT.name}: $it" } }
+    this.find { it.vedtakfaktaKode == ArenaVedtakFakta.DAGUTBTILT.name }?.vedtakfaktaVerdi
+        .also { log.info { "${ArenaVedtakFakta.DAGUTBTILT.name}: $it" } }
         ?.toDouble()
 
 private fun List<ArenaVedtakfaktaDTO>.relatertTiltak(): String? =
-    this.find { it.vedtakfaktaKode == ArenaLovligeVedtakFaktaForTiltakspenger.KODETILTAK.name }?.vedtakfaktaVerdi
-        .also { log.info { "${ArenaLovligeVedtakFaktaForTiltakspenger.KODETILTAK.name}: $it" } }
+    this.find { it.vedtakfaktaKode == ArenaVedtakFakta.KODETILTAK.name }?.vedtakfaktaVerdi
+        .also { log.info { "${ArenaVedtakFakta.KODETILTAK.name}: $it" } }
 
 private fun List<ArenaVedtakfaktaDTO>.relatertTiltakNavn(): String? =
-    this.find { it.vedtakfaktaKode == ArenaLovligeVedtakFaktaForTiltakspenger.TILTAKNAVN.name }?.vedtakfaktaVerdi
-        .also { log.info { "${ArenaLovligeVedtakFaktaForTiltakspenger.TILTAKNAVN.name}: $it" } }
+    this.find { it.vedtakfaktaKode == ArenaVedtakFakta.TILTAKNAVN.name }?.vedtakfaktaVerdi
+        .also { log.info { "${ArenaVedtakFakta.TILTAKNAVN.name}: $it" } }
 
 private fun List<ArenaVedtakfaktaDTO>.opprinneligTilDato(): LocalDate? =
-    this.find { it.vedtakfaktaKode == ArenaLovligeVedtakFaktaForTiltakspenger.OPPRTDATO.name }?.vedtakfaktaVerdi
-        .also { log.info { "${ArenaLovligeVedtakFaktaForTiltakspenger.OPPRTDATO.name}: $it" } }
+    this.find { it.vedtakfaktaKode == ArenaVedtakFakta.OPPRTDATO.name }?.vedtakfaktaVerdi
+        .also { log.info { "${ArenaVedtakFakta.OPPRTDATO.name}: $it" } }
         ?.let { LocalDate.parse(it, DateTimeFormatter.ofPattern("dd-MM-yyyy")) }
+
+private fun List<ArenaVedtakfaktaDTO>.gjelderFra(): LocalDate? =
+    this.find { it.vedtakfaktaKode == ArenaVedtakFakta.FDATO.name }?.vedtakfaktaVerdi
+        .also { log.info { "${ArenaVedtakFakta.FDATO.name}: $it" } }
+        ?.let { LocalDate.parse(it, DateTimeFormatter.ofPattern("dd-MM-yyyy")) }
+
+private fun List<ArenaVedtakfaktaDTO>.gjelderTil(): LocalDate? =
+    this.find { it.vedtakfaktaKode == ArenaVedtakFakta.TDATO.name }?.vedtakfaktaVerdi
+        .also { log.info { "${ArenaVedtakFakta.TDATO.name}: $it" } }
+        ?.let { LocalDate.parse(it, DateTimeFormatter.ofPattern("dd-MM-yyyy")) }
+
+private fun List<ArenaVedtakfaktaDTO>.satsKode(): String? =
+    this.find { it.vedtakfaktaKode == ArenaVedtakFakta.SATSKODE.name }?.vedtakfaktaVerdi
+        .also { log.info { "${ArenaVedtakFakta.SATSKODE.name}: $it" } }
+
+private fun List<ArenaVedtakfaktaDTO>.maskineltVedtak(): String? =
+    this.find { it.vedtakfaktaKode == ArenaVedtakFakta.MASKVEDTAK.name }?.vedtakfaktaVerdi
+        .also { log.info { "${ArenaVedtakFakta.MASKVEDTAK.name}: $it" } }

--- a/src/main/kotlin/no/nav/tiltakspenger/arena/repository/BarnetilleggVedtakDAO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/arena/repository/BarnetilleggVedtakDAO.kt
@@ -6,7 +6,7 @@ import kotliquery.queryOf
 import mu.KotlinLogging
 import org.intellij.lang.annotations.Language
 
-class VedtakDAO(
+class BarnetilleggVedtakDAO(
     private val vedtakfaktaDAO: VedtakfaktaDAO = VedtakfaktaDAO(),
 ) {
 
@@ -33,10 +33,10 @@ class VedtakDAO(
             ArenaUtfall.valueOf(this)
     }
 
-    fun findAlleBySakId(
+    private fun findAlleBarnetilleggBySakId(
         sakId: Long,
         txSession: TransactionalSession,
-    ): List<ArenaVedtakDTO> {
+    ): List<ArenaBarnetilleggVedtakDTO> {
         val paramMap = mapOf(
             "sak_id" to sakId,
         )
@@ -47,15 +47,15 @@ class VedtakDAO(
         )
     }
 
-    fun findBySakId(
+    fun findBarnetilleggBySakId(
         sakId: Long,
         txSession: TransactionalSession,
-    ): List<ArenaVedtakDTO> = findAlleBySakId(sakId, txSession)
+    ): List<ArenaBarnetilleggVedtakDTO> = findAlleBarnetilleggBySakId(sakId, txSession)
 
-    private fun Row.toVedtak(txSession: TransactionalSession): ArenaVedtakDTO {
+    private fun Row.toVedtak(txSession: TransactionalSession): ArenaBarnetilleggVedtakDTO {
         val vedtakId = long("VEDTAK_ID")
-        val vedtakFakta = vedtakfaktaDAO.findByVedtakId(vedtakId, txSession)
-        val dto = ArenaVedtakDTO(
+        val vedtakFakta = vedtakfaktaDAO.findBarnetilleggVedtakfaktaByVedtakId(vedtakId, txSession)
+        val dto = ArenaBarnetilleggVedtakDTO(
             beslutningsdato = vedtakFakta.beslutningsdato,
             vedtakType = string("VEDTAKTYPEKODE").toVedtakType(),
             uttaksgrad = 100,
@@ -88,8 +88,7 @@ class VedtakDAO(
         SELECT *
         FROM vedtak v
         WHERE v.sak_id = :sak_id
-        -- AND v.rettighetkode IN ('BASI', 'BTIL') -- Venter litt med BTIL (Barnetillegg)
-        AND v.rettighetkode = 'BASI'
+        AND v.rettighetkode = 'BTIL'
         AND v.vedtaktypekode IN ('O', 'E', 'G') --Ny rettighet, endring, gjenopptak
         AND v.utfallkode NOT IN ('AVBRUTT', 'NEI') --Vi vil bare ha positive vedtak
         AND v.vedtakstatuskode IN ('IVERK', 'AVSLU') --Vi vil bare ha vedtak som faktisk er vedtatt

--- a/src/main/kotlin/no/nav/tiltakspenger/arena/repository/SakDAO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/arena/repository/SakDAO.kt
@@ -7,7 +7,8 @@ import mu.KotlinLogging
 import org.intellij.lang.annotations.Language
 
 class SakDAO(
-    private val vedtakDAO: VedtakDAO = VedtakDAO(),
+    private val tiltakspengerVedtakDAO: TiltakspengerVedtakDAO = TiltakspengerVedtakDAO(),
+    private val barnetilleggVedtakDAO: BarnetilleggVedtakDAO = BarnetilleggVedtakDAO(),
 ) {
     companion object {
         private val LOG = KotlinLogging.logger {}
@@ -36,16 +37,20 @@ class SakDAO(
 
     private fun Row.toSak(txSession: TransactionalSession): ArenaSakDTO {
         val sakId = long("SAK_ID")
-        val vedtak = vedtakDAO.findBySakId(sakId, txSession)
-        LOG.info { "Antall vedtak er ${vedtak.size} for sak med id $sakId" }
-        SECURELOG.info { "Antall vedtak er ${vedtak.size} for sak med id $sakId" }
+        val tiltakspengerVedtak = tiltakspengerVedtakDAO.findTiltakspengerBySakId(sakId, txSession)
+        val barnetilleggVedtak = barnetilleggVedtakDAO.findBarnetilleggBySakId(sakId, txSession)
+        LOG.info { "Antall tiltakspengerVedtak er ${tiltakspengerVedtak.size} for sak med id $sakId" }
+        LOG.info { "Antall barnetilleggVedtak er ${barnetilleggVedtak.size} for sak med id $sakId" }
+        SECURELOG.info { "Antall tiltakspengerVedtak er ${tiltakspengerVedtak.size} for sak med id $sakId" }
+        SECURELOG.info { "Antall barnetilleggVedtak er ${barnetilleggVedtak.size} for sak med id $sakId" }
 
         return ArenaSakDTO(
             aar = int("AAR"),
             lopenrSak = long("LOPENRSAK"),
             status = string("SAKSTATUSKODE").toStatus(),
             ytelsestype = string("SAKSKODE").toYtelse(),
-            vedtak = vedtak,
+            tiltakspengerVedtak = tiltakspengerVedtak,
+            barnetilleggVedtak = barnetilleggVedtak,
         )
     }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/arena/repository/SakRepository.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/arena/repository/SakRepository.kt
@@ -35,7 +35,7 @@ class SakRepository(
     fun hentSakerForFnr(
         fnr: String,
         fom: LocalDate = LocalDate.of(1900, 1, 1),
-        tom: LocalDate = LocalDate.of(2299, 12, 31),
+        tom: LocalDate = LocalDate.of(2999, 12, 31),
     ): List<ArenaSakDTO> {
         val saker = hentAlleSakerForFnr(fnr)
             .kunSakerMedVedtakInnenforPeriode(fom, tom)

--- a/src/main/kotlin/no/nav/tiltakspenger/arena/repository/TiltakspengerVedtakDAO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/arena/repository/TiltakspengerVedtakDAO.kt
@@ -1,0 +1,99 @@
+package no.nav.tiltakspenger.arena.repository
+
+import kotliquery.Row
+import kotliquery.TransactionalSession
+import kotliquery.queryOf
+import mu.KotlinLogging
+import org.intellij.lang.annotations.Language
+
+class TiltakspengerVedtakDAO(
+    private val vedtakfaktaDAO: VedtakfaktaDAO = VedtakfaktaDAO(),
+) {
+
+    companion object {
+        private val LOG = KotlinLogging.logger {}
+        private val SECURELOG = KotlinLogging.logger("tjenestekall")
+
+        private fun String.toVedtakType(): ArenaVedtakType =
+            ArenaVedtakType.valueOf(this)
+
+        private fun String.toVedtakStatus(): ArenaVedtakStatus =
+            ArenaVedtakStatus.valueOf(this)
+
+        private fun String.toRettighetType(): ArenaRettighet =
+            ArenaRettighet.valueOf(this)
+
+        private fun String.toYtelseType(): ArenaYtelse =
+            ArenaYtelse.valueOf(this)
+
+        private fun String.toAktivitetFase(): ArenaAktivitetFase =
+            ArenaAktivitetFase.valueOf(this)
+
+        private fun String.toUtfall(): ArenaUtfall =
+            ArenaUtfall.valueOf(this)
+    }
+
+    private fun findAlleTiltakspengerBySakId(
+        sakId: Long,
+        txSession: TransactionalSession,
+    ): List<ArenaTiltakspengerVedtakDTO> {
+        val paramMap = mapOf(
+            "sak_id" to sakId,
+        )
+        return txSession.run(
+            queryOf(findBySQL, paramMap)
+                .map { row -> row.toVedtak(txSession) }
+                .asList,
+        )
+    }
+
+    fun findTiltakspengerBySakId(
+        sakId: Long,
+        txSession: TransactionalSession,
+    ): List<ArenaTiltakspengerVedtakDTO> = findAlleTiltakspengerBySakId(sakId, txSession)
+
+    private fun Row.toVedtak(txSession: TransactionalSession): ArenaTiltakspengerVedtakDTO {
+        val vedtakId = long("VEDTAK_ID")
+        val vedtakFakta = vedtakfaktaDAO.findTiltakspengerVedtakfaktaByVedtakId(vedtakId, txSession)
+        val dto = ArenaTiltakspengerVedtakDTO(
+            beslutningsdato = vedtakFakta.beslutningsdato,
+            vedtakType = string("VEDTAKTYPEKODE").toVedtakType(),
+            uttaksgrad = 100,
+            status = string("VEDTAKSTATUSKODE").toVedtakStatus(),
+            rettighettype = string("RETTIGHETKODE").toRettighetType(),
+            aktivitetsfase = string("AKTFASEKODE").toAktivitetFase(),
+            dagsats = vedtakFakta.dagsats,
+            fomVedtaksperiode = localDate("FRA_DATO"),
+            tomVedtaksperiode = localDateOrNull("TIL_DATO"),
+            mottattDato = localDate("DATO_MOTTATT"),
+            registrertDato = localDateOrNull("REG_DATO"),
+            utfall = string("UTFALLKODE").toUtfall(),
+            antallDager = vedtakFakta.antallDager,
+            opprinneligTomVedtaksperiode = vedtakFakta.opprinneligTilDato,
+            relatertTiltak = vedtakFakta.relatertTiltak,
+
+        )
+
+        if (!(dto.status == ArenaVedtakStatus.GODKJ || dto.status == ArenaVedtakStatus.IVERK)) {
+            LOG.info { "VedtakStatusType er ${dto.status}" }
+        }
+        return dto
+    }
+
+    // Vi gjør filtreringen her i stedet for i Kotlin-koden, da de ulike where-clausene er ganske enkle å forstå,
+    // og det er kjappere å filtrere i db.
+    @Language("SQL")
+    private val findBySQL =
+        """
+        SELECT *
+        FROM vedtak v
+        WHERE v.sak_id = :sak_id
+        AND v.rettighetkode = 'BASI'
+        AND v.vedtaktypekode IN ('O', 'E', 'G') --Ny rettighet, endring, gjenopptak
+        AND v.utfallkode NOT IN ('AVBRUTT', 'NEI') --Vi vil bare ha positive vedtak
+        AND v.vedtakstatuskode IN ('IVERK', 'AVSLU') --Vi vil bare ha vedtak som faktisk er vedtatt
+        AND v.fra_dato IS NOT NULL --Ekskluderer spesialutbetalinger
+        AND v.fra_dato <= NVL(v.til_dato, v.fra_dato) --Ekskluderer ugyldiggjorte vedtak
+        ORDER BY v.lopenrvedtak DESC
+        """.trimIndent()
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/arena/repository/VedtakfaktaDAO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/arena/repository/VedtakfaktaDAO.kt
@@ -12,7 +12,7 @@ class VedtakfaktaDAO {
         private val securelog = KotlinLogging.logger("tjenestekall")
     }
 
-    fun findByVedtakId(
+    fun findTiltakspengerVedtakfaktaByVedtakId(
         vedtakId: Long,
         txSession: TransactionalSession,
     ): ArenaTiltakspengerVedtakfaktaDTO {
@@ -24,6 +24,20 @@ class VedtakfaktaDAO {
                 .map { row -> row.toVedtakfakta() }
                 .asList,
         ).toArenaTiltakspengerVedtakfaktaDTO()
+    }
+
+    fun findBarnetilleggVedtakfaktaByVedtakId(
+        vedtakId: Long,
+        txSession: TransactionalSession,
+    ): ArenaBarnetilleggVedtakfaktaDTO {
+        val paramMap = mapOf(
+            "vedtak_id" to vedtakId.toString(),
+        )
+        return txSession.run(
+            queryOf(findBySQL, paramMap)
+                .map { row -> row.toVedtakfakta() }
+                .asList,
+        ).toArenaBarnetilleggVedtakfaktaDTO()
     }
 
     private fun Row.toVedtakfakta(): ArenaVedtakfaktaDTO {

--- a/src/main/kotlin/no/nav/tiltakspenger/arena/routes/TiltakspengerRoutesUtenAuth.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/arena/routes/TiltakspengerRoutesUtenAuth.kt
@@ -7,7 +7,10 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
 import mu.KotlinLogging
 import no.nav.tiltakspenger.arena.felles.Periode
+import no.nav.tiltakspenger.arena.felles.PeriodeMedVerdier
+import no.nav.tiltakspenger.arena.service.Rettighet
 import no.nav.tiltakspenger.arena.service.TiltakepengerPerioderService
+import no.nav.tiltakspenger.arena.service.VedtakDetaljer
 import java.time.LocalDate
 
 private val SECURELOG = KotlinLogging.logger("tjenestekall")
@@ -17,9 +20,9 @@ fun Route.tiltakspengerRoutesUtenAuth(service: TiltakepengerPerioderService) {
         try {
             val ident =
                 call.receive<RequestBody>().ident
-            val sammenhengendePerioder: List<Periode> =
+            val periode: PeriodeMedVerdier<VedtakDetaljer>? =
                 service.hentTiltakspengerPerioder(ident = ident)
-            call.respond(sammenhengendePerioder.map { it.toPeriodeDTO() })
+            call.respond(periode.toPeriodeDTO())
         } catch (e: Exception) {
             SECURELOG.warn("Feil i kall mot Arena for å hente tiltakspenger ${e.message}", e)
             call.respond(emptyList<Periode>())
@@ -27,5 +30,33 @@ fun Route.tiltakspengerRoutesUtenAuth(service: TiltakepengerPerioderService) {
     }
 }
 
-private fun Periode.toPeriodeDTO() = PeriodeDTO(this.fra, this.til)
-private data class PeriodeDTO(val fraOgMed: LocalDate, val tilOgMed: LocalDate?)
+private fun PeriodeMedVerdier<VedtakDetaljer>?.toPeriodeDTO(): List<PeriodeDTO> =
+    this?.perioder()?.map {
+        PeriodeDTO(
+            fraOgMed = it.periode.fra,
+            tilOgMed = it.periode.til.toNullIfMax(),
+            antallDager = it.verdi.antallDager,
+            dagsatsTiltakspenger = it.verdi.dagsatsTiltakspenger,
+            dagsatsBarnetillegg = it.verdi.dagsatsBarnetillegg,
+            antallBarn = it.verdi.antallBarn,
+            relaterteTiltak = it.verdi.relaterteTiltak,
+            rettighet = it.verdi.rettighet,
+        )
+    } ?: emptyList()
+
+private fun LocalDate.toNullIfMax(): LocalDate? = if (this == LocalDate.MAX) {
+    null
+} else {
+    this
+}
+
+private data class PeriodeDTO(
+    val fraOgMed: LocalDate,
+    val tilOgMed: LocalDate?,
+    val antallDager: Double,
+    val dagsatsTiltakspenger: Int,
+    val dagsatsBarnetillegg: Int,
+    val antallBarn: Int,
+    val relaterteTiltak: String,
+    val rettighet: Rettighet,
+)

--- a/src/main/kotlin/no/nav/tiltakspenger/arena/service/Mapper.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/arena/service/Mapper.kt
@@ -1,0 +1,117 @@
+package no.nav.tiltakspenger.arena.service
+
+import mu.KotlinLogging
+import no.nav.tiltakspenger.arena.felles.Periode
+import no.nav.tiltakspenger.arena.felles.PeriodeMedVerdier
+import no.nav.tiltakspenger.arena.repository.ArenaBarnetilleggVedtakDTO
+import no.nav.tiltakspenger.arena.repository.ArenaSakDTO
+import no.nav.tiltakspenger.arena.repository.ArenaTiltakspengerVedtakDTO
+
+private val SECURELOG = KotlinLogging.logger("tjenestekall")
+
+fun mapTiltakspengerFraArenaTilVedtaksperioder(saker: List<ArenaSakDTO>): PeriodeMedVerdier<VedtakDetaljer>? {
+    val totalePeriodeFra = saker.minOfOrNull { it.sakPeriode()!!.fra }
+    val totalePeriodeTil = saker.maxOfOrNull { it.sakPeriode()!!.til }
+    if (totalePeriodeFra == null) {
+        SECURELOG.info { "Returnerer null pga ingen saksperiode" }
+        return null
+    }
+    val totalePeriode = Periode(totalePeriodeFra, totalePeriodeTil!!)
+    val periodeMedTiltakspengerInit = PeriodeMedVerdier(
+        totalePeriode = totalePeriode,
+        defaultVerdi = VedtakDetaljerUtenBarnetillegg(
+            antallDager = 0.0,
+            dagsats = 0,
+            relaterteTiltak = "",
+            rettighet = Rettighet.INGENTING,
+        ),
+    )
+    val periodeMedBarnetilleggInit = PeriodeMedVerdier(
+        totalePeriode = totalePeriode,
+        defaultVerdi = VedtakDetaljerBarnetillegg(
+            antallDager = 0.0,
+            dagsats = 0,
+            antallBarn = 0,
+            relaterteTiltak = "",
+            rettighet = Rettighet.INGENTING,
+        ),
+    )
+    val periodeMedTiltakspenger =
+        saker
+            .flatMap { it.tiltakspengerVedtak }
+            .fold(periodeMedTiltakspengerInit) { periodeMedVerdier: PeriodeMedVerdier<VedtakDetaljerUtenBarnetillegg>, arenaTiltakspengerVedtakDTO: ArenaTiltakspengerVedtakDTO ->
+                periodeMedVerdier.setVerdiForDelPeriode(
+                    VedtakDetaljerUtenBarnetillegg(
+                        antallDager = arenaTiltakspengerVedtakDTO.antallDager!!,
+                        dagsats = arenaTiltakspengerVedtakDTO.dagsats!!,
+                        relaterteTiltak = arenaTiltakspengerVedtakDTO.relatertTiltak!!,
+                        rettighet = Rettighet.TILTAKSPENGER,
+                    ),
+                    arenaTiltakspengerVedtakDTO.vedtaksperiode(),
+                )
+            }
+
+    val periodeMedBarnetillegg =
+        saker
+            .flatMap { it.barnetilleggVedtak }
+            .fold(periodeMedBarnetilleggInit) { periodeMedVerdier: PeriodeMedVerdier<VedtakDetaljerBarnetillegg>, arenaBarnetilleggVedtakDTO: ArenaBarnetilleggVedtakDTO ->
+                if (totalePeriode.inneholderHele(arenaBarnetilleggVedtakDTO.vedtaksperiode())) {
+                    SECURELOG.info { "Perioden for barnetillegg (${arenaBarnetilleggVedtakDTO.vedtaksperiode()}) er innenfor saksperioden ($totalePeriode) " }
+                    // Legger til hele perioden
+                    periodeMedVerdier.setVerdiForDelPeriode(
+                        VedtakDetaljerBarnetillegg(
+                            antallDager = arenaBarnetilleggVedtakDTO.antallDager!!,
+                            dagsats = arenaBarnetilleggVedtakDTO.dagsats!!,
+                            antallBarn = arenaBarnetilleggVedtakDTO.antallBarn!!,
+                            relaterteTiltak = arenaBarnetilleggVedtakDTO.relatertTiltak!!,
+                            rettighet = Rettighet.BARNETILLEGG,
+                        ),
+                        arenaBarnetilleggVedtakDTO.vedtaksperiode(),
+                    )
+                } else if (totalePeriode.overlapperMed(arenaBarnetilleggVedtakDTO.vedtaksperiode())) {
+                    SECURELOG.info { "Perioden for barnetillegg (${arenaBarnetilleggVedtakDTO.vedtaksperiode()}) overlapper med saksperioden ($totalePeriode) " }
+                    periodeMedVerdier.setVerdiForDelPeriode(
+                        VedtakDetaljerBarnetillegg(
+                            antallDager = arenaBarnetilleggVedtakDTO.antallDager!!,
+                            dagsats = arenaBarnetilleggVedtakDTO.dagsats!!,
+                            antallBarn = arenaBarnetilleggVedtakDTO.antallBarn!!,
+                            relaterteTiltak = arenaBarnetilleggVedtakDTO.relatertTiltak!!,
+                            rettighet = Rettighet.BARNETILLEGG,
+                        ),
+                        arenaBarnetilleggVedtakDTO.vedtaksperiode().overlappendePeriode(totalePeriode)!!,
+                    )
+                } else {
+                    SECURELOG.info { "Perioden for barnetillegg (${arenaBarnetilleggVedtakDTO.vedtaksperiode()}) er utenfor saksperioden ($totalePeriode) " }
+                    // Legger ikke til noe
+                    periodeMedVerdier
+                }
+            }
+    SECURELOG.info { "Periode med tiltakspenger: $periodeMedTiltakspenger" }
+    SECURELOG.info { "Periode med barnetillegg: $periodeMedBarnetillegg" }
+
+    return periodeMedTiltakspenger.kombiner(periodeMedBarnetillegg) { vt, vb ->
+        if (vt.rettighet == Rettighet.TILTAKSPENGER && vb.rettighet == Rettighet.BARNETILLEGG && vt.antallDager != vb.antallDager) {
+            SECURELOG.info { "Vedtaket om tiltakspenger (${vt.antallDager}) og vedtaket om barnetillegg (${vb.antallDager}) har ikke samme antall dager" }
+        }
+        if (vt.rettighet == Rettighet.TILTAKSPENGER && vb.rettighet == Rettighet.BARNETILLEGG && vt.relaterteTiltak != vb.relaterteTiltak) {
+            SECURELOG.info { "Vedtaket om tiltakspenger (${vt.relaterteTiltak}) og vedtaket om barnetillegg (${vb.relaterteTiltak}) har ikke samme relaterte tiltak" }
+        }
+        VedtakDetaljer(
+            antallDager = vt.antallDager,
+            dagsatsTiltakspenger = vt.dagsats,
+            dagsatsBarnetillegg = vb.dagsats,
+            antallBarn = vb.antallBarn,
+            relaterteTiltak = vt.relaterteTiltak,
+            rettighet = if (vt.rettighet == Rettighet.TILTAKSPENGER && vb.rettighet == Rettighet.BARNETILLEGG) {
+                Rettighet.TILTAKSPENGER_OG_BARNETILLEGG
+            } else if (vt.rettighet == Rettighet.TILTAKSPENGER && vb.rettighet == Rettighet.INGENTING) {
+                Rettighet.TILTAKSPENGER
+            } else if (vt.rettighet == Rettighet.INGENTING && vb.rettighet == Rettighet.BARNETILLEGG) {
+                SECURELOG.info { "Her har vi en periode med barnetillegg men ikke tiltakspenger - det skal ikke egentlig kunne skje!" }
+                Rettighet.BARNETILLEGG
+            } else {
+                Rettighet.INGENTING
+            },
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/arena/service/VedtakPeriode.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/arena/service/VedtakPeriode.kt
@@ -1,0 +1,32 @@
+package no.nav.tiltakspenger.arena.service
+
+enum class Rettighet {
+    TILTAKSPENGER,
+    BARNETILLEGG,
+    TILTAKSPENGER_OG_BARNETILLEGG,
+    INGENTING,
+}
+
+data class VedtakDetaljer(
+    val antallDager: Double,
+    val dagsatsTiltakspenger: Int,
+    val dagsatsBarnetillegg: Int,
+    val antallBarn: Int,
+    val relaterteTiltak: String,
+    val rettighet: Rettighet,
+)
+
+data class VedtakDetaljerUtenBarnetillegg(
+    val antallDager: Double,
+    val dagsats: Int,
+    val relaterteTiltak: String,
+    val rettighet: Rettighet,
+)
+
+data class VedtakDetaljerBarnetillegg(
+    val antallDager: Double,
+    val dagsats: Int,
+    val antallBarn: Int,
+    val relaterteTiltak: String,
+    val rettighet: Rettighet,
+)

--- a/src/main/kotlin/no/nav/tiltakspenger/arena/ytelser/DbMapper.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/arena/ytelser/DbMapper.kt
@@ -1,7 +1,7 @@
 package no.nav.tiltakspenger.arena.ytelser
 
 import no.nav.tiltakspenger.arena.repository.ArenaSakDTO
-import no.nav.tiltakspenger.arena.repository.ArenaVedtakDTO
+import no.nav.tiltakspenger.arena.repository.ArenaTiltakspengerVedtakDTO
 import no.nav.tiltakspenger.libs.arena.ytelse.ArenaYtelseResponsDTO
 
 fun mapArenaYtelserFraDB(saker: List<ArenaSakDTO>): ArenaYtelseResponsDTO =
@@ -15,10 +15,10 @@ fun mapSakFraDB(sak: ArenaSakDTO): ArenaYtelseResponsDTO.SakDTO =
         fagsystemSakId = sak.fagsystemSakId,
         status = ArenaYtelseResponsDTO.SakStatusType.valueOf(sak.status.name),
         sakType = ArenaYtelseResponsDTO.SakType.valueOf(sak.ytelsestype.name),
-        vedtak = mapVedtakFraDB(sak.vedtak),
+        vedtak = mapVedtakFraDB(sak.tiltakspengerVedtak),
     )
 
-fun mapVedtakFraDB(vedtakListe: List<ArenaVedtakDTO>): List<ArenaYtelseResponsDTO.VedtakDTO> =
+fun mapVedtakFraDB(vedtakListe: List<ArenaTiltakspengerVedtakDTO>): List<ArenaYtelseResponsDTO.VedtakDTO> =
     vedtakListe.map { vedtak ->
         ArenaYtelseResponsDTO.VedtakDTO(
             beslutningsDato = vedtak.beslutningsdato,

--- a/src/test/kotlin/no/nav/tiltakspenger/arena/felles/PeriodeKtTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/arena/felles/PeriodeKtTest.kt
@@ -1,0 +1,17 @@
+package no.nav.tiltakspenger.arena.felles
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class PeriodeKtTest {
+
+    @Test
+    fun testTrekkFraPerioder() {
+        val perioder1 = listOf(Periode(LocalDate.of(2020, 10, 1), LocalDate.of(2023, 10, 10)))
+        val perioder2 = listOf(Periode(LocalDate.of(2020, 10, 1), LocalDate.of(2023, 10, 10)))
+        val tomPeriode = perioder1.trekkFra(perioder2)
+        println(tomPeriode)
+        tomPeriode.size shouldBe 0
+    }
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/arena/felles/PeriodeMedVerdierAvLikTypeTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/arena/felles/PeriodeMedVerdierAvLikTypeTest.kt
@@ -1,0 +1,100 @@
+package no.nav.tiltakspenger.arena.felles
+
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+enum class Utfall {
+    OPPFYLT,
+    IKKE_OPPFYLT,
+    KREVER_MANUELL_VURDERING,
+}
+
+class PeriodeMedVerdierAvLikTypeTest {
+    @Test
+    fun test1() {
+        val aap =
+            PeriodeMedVerdier(
+                Utfall.IKKE_OPPFYLT,
+                Periode(1.oktober(2023), 10.oktober(2023)),
+            )
+                .setVerdiForDelPeriode(Utfall.OPPFYLT, Periode(6.oktober(2023), 10.oktober(2023)))
+
+        val dagpenger =
+            PeriodeMedVerdier(
+                Utfall.OPPFYLT,
+                Periode(1.oktober(2023), 10.oktober(2023)),
+            )
+
+        val vedtak = aap.kombiner(dagpenger, ::kombinerToUfall)
+        vedtak.perioder().size shouldBe 2
+
+        vedtak.perioder().count { it.verdi == Utfall.OPPFYLT } shouldBe 1
+        vedtak.perioder()
+            .find { it.verdi == Utfall.OPPFYLT }!!.periode shouldBe Periode(6.oktober(2023), 10.oktober(2023))
+
+        vedtak.perioder().count { it.verdi == Utfall.IKKE_OPPFYLT } shouldBe 1
+        vedtak.perioder()
+            .find { it.verdi == Utfall.IKKE_OPPFYLT }!!.periode shouldBe Periode(1.oktober(2023), 5.oktober(2023))
+    }
+
+    @Test
+    fun testFireVilkår() {
+        val aap =
+            PeriodeMedVerdier(
+                Utfall.OPPFYLT,
+                Periode(1.oktober(2023), 10.oktober(2023)),
+            )
+                .setVerdiForDelPeriode(Utfall.IKKE_OPPFYLT, Periode(6.oktober(2023), 10.oktober(2023)))
+
+        val fengsel =
+            PeriodeMedVerdier(
+                Utfall.OPPFYLT,
+                Periode(1.oktober(2023), 10.oktober(2023)),
+            )
+                .setVerdiForDelPeriode(Utfall.IKKE_OPPFYLT, Periode(1.oktober(2023), 2.oktober(2023)))
+
+        val jobbsjansen =
+            PeriodeMedVerdier(
+                Utfall.OPPFYLT,
+                Periode(1.oktober(2023), 10.oktober(2023)),
+            )
+                .setVerdiForDelPeriode(Utfall.IKKE_OPPFYLT, Periode(5.oktober(2023), 7.oktober(2023)))
+
+        val dagpenger =
+            PeriodeMedVerdier(
+                Utfall.OPPFYLT,
+                Periode(1.oktober(2023), 10.oktober(2023)),
+            )
+
+        val alleVilkår = listOf(aap, dagpenger, fengsel, jobbsjansen)
+
+        val vedtak = PeriodeMedVerdier.kombinerLikePerioderMedSammeTypeVerdier(alleVilkår, ::kombinerToUfall)
+        println(vedtak)
+        vedtak.perioder().size shouldBe 3
+
+        vedtak.perioder()
+            .count { it.verdi == Utfall.OPPFYLT } shouldBe 1
+        vedtak.perioder()
+            .filter { it.verdi == Utfall.OPPFYLT }
+            .map { it.periode } shouldContainExactly listOf(Periode(3.oktober(2023), 4.oktober(2023)))
+
+        vedtak.perioder()
+            .count { it.verdi == Utfall.IKKE_OPPFYLT } shouldBe 2
+        vedtak.perioder()
+            .filter { it.verdi == Utfall.IKKE_OPPFYLT }.map { it.periode } shouldContainExactly listOf(
+            Periode(1.oktober(2023), 2.oktober(2023)),
+            Periode(5.oktober(2023), 10.oktober(2023)),
+        )
+    }
+
+    private fun kombinerToUfall(en: Utfall, to: Utfall): Utfall {
+        if (en == Utfall.KREVER_MANUELL_VURDERING || to == Utfall.KREVER_MANUELL_VURDERING) {
+            return Utfall.KREVER_MANUELL_VURDERING
+        }
+        if (en == Utfall.IKKE_OPPFYLT || to == Utfall.IKKE_OPPFYLT) {
+            return Utfall.IKKE_OPPFYLT
+        }
+        return Utfall.OPPFYLT
+    }
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/arena/felles/PeriodeMedVerdierAvUlikTypeTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/arena/felles/PeriodeMedVerdierAvUlikTypeTest.kt
@@ -1,0 +1,113 @@
+package no.nav.tiltakspenger.arena.felles
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class PeriodeMedVerdierAvUlikTypeTest {
+    data class DagsatsOgAntallBarn(
+        val dagsats: Long,
+        val antallBarn: Int,
+    ) {
+        companion object {
+            fun kombinerDagsatsOgAntallBarn(dagsats: Long, antallBarn: Int): DagsatsOgAntallBarn =
+                DagsatsOgAntallBarn(dagsats, antallBarn)
+
+            fun trekkUtDagsats(dagsatsOgAntallBarn: DagsatsOgAntallBarn): Long = dagsatsOgAntallBarn.dagsats
+            fun trekkUtAntallBarn(dagsatsOgAntallBarn: DagsatsOgAntallBarn): Int = dagsatsOgAntallBarn.antallBarn
+        }
+    }
+
+    @Test
+    fun test1() {
+        val perioderMedDagsats =
+            PeriodeMedVerdier(255L, Periode(1.oktober(2023), 10.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(1.oktober(2023), 1.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(2.oktober(2023), 2.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(3.oktober(2023), 3.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(4.oktober(2023), 4.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(5.oktober(2023), 5.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(6.oktober(2023), 6.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(7.oktober(2023), 7.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(8.oktober(2023), 8.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(9.oktober(2023), 9.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(10.oktober(2023), 10.oktober(2023)))
+        perioderMedDagsats.perioder().size shouldBe 1
+    }
+
+    @Test
+    fun test2() {
+        val perioderMedDagsats =
+            PeriodeMedVerdier(255L, Periode(1.oktober(2023), 10.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(1.oktober(2023), 1.oktober(2023)))
+                .setVerdiForDelPeriode(301L, Periode(2.oktober(2023), 2.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(3.oktober(2023), 3.oktober(2023)))
+                .setVerdiForDelPeriode(301L, Periode(4.oktober(2023), 4.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(5.oktober(2023), 5.oktober(2023)))
+                .setVerdiForDelPeriode(301L, Periode(6.oktober(2023), 6.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(7.oktober(2023), 7.oktober(2023)))
+                .setVerdiForDelPeriode(301L, Periode(8.oktober(2023), 8.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(9.oktober(2023), 9.oktober(2023)))
+                .setVerdiForDelPeriode(301L, Periode(10.oktober(2023), 10.oktober(2023)))
+        perioderMedDagsats.perioder().size shouldBe 10
+    }
+
+    @Test
+    fun test3() {
+        val perioderMedDagsats =
+            PeriodeMedVerdier(255L, Periode(1.oktober(2023), 10.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(1.oktober(2023), 1.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(2.oktober(2023), 2.oktober(2023)))
+                .setVerdiForDelPeriode(301L, Periode(3.oktober(2023), 3.oktober(2023)))
+                .setVerdiForDelPeriode(301L, Periode(4.oktober(2023), 4.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(5.oktober(2023), 5.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(6.oktober(2023), 6.oktober(2023)))
+                .setVerdiForDelPeriode(301L, Periode(7.oktober(2023), 7.oktober(2023)))
+                .setVerdiForDelPeriode(301L, Periode(8.oktober(2023), 8.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(9.oktober(2023), 9.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(10.oktober(2023), 10.oktober(2023)))
+        perioderMedDagsats.perioder().size shouldBe 5
+        perioderMedDagsats.perioder().count { it.verdi == 300L } shouldBe 3
+        perioderMedDagsats.perioder().count { it.verdi == 301L } shouldBe 2
+        perioderMedDagsats.perioder().count { it.verdi == 255L } shouldBe 0
+    }
+
+    @Test
+    fun test4() {
+        fun kontrollerDagsats(perioderMedDagsats: PeriodeMedVerdier<Long>) {
+            perioderMedDagsats.perioder().size shouldBe 2
+            perioderMedDagsats.perioder().count { it.verdi == 300L } shouldBe 1
+            perioderMedDagsats.perioder().count { it.verdi == 301L } shouldBe 1
+            perioderMedDagsats.perioder().count { it.verdi == 255L } shouldBe 0
+        }
+
+        fun kontrollerAntallBarn(perioderMedAntallBarn: PeriodeMedVerdier<Int>) {
+            perioderMedAntallBarn.perioder().size shouldBe 3
+            perioderMedAntallBarn.perioder().count { it.verdi == 1 } shouldBe 2
+            perioderMedAntallBarn.perioder().count { it.verdi == 2 } shouldBe 1
+            perioderMedAntallBarn.perioder().count { it.verdi == 0 } shouldBe 0
+        }
+
+        val perioderMedDagsats =
+            PeriodeMedVerdier(255L, Periode(1.oktober(2023), 4.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(1.oktober(2023), 1.oktober(2023)))
+                .setVerdiForDelPeriode(300L, Periode(2.oktober(2023), 2.oktober(2023)))
+                .setVerdiForDelPeriode(301L, Periode(3.oktober(2023), 3.oktober(2023)))
+                .setVerdiForDelPeriode(301L, Periode(4.oktober(2023), 4.oktober(2023)))
+        kontrollerDagsats(perioderMedDagsats)
+
+        val perioderMedAntallBarn =
+            PeriodeMedVerdier(0, Periode(1.oktober(2023), 4.oktober(2023)))
+                .setVerdiForDelPeriode(1, Periode(1.oktober(2023), 1.oktober(2023)))
+                .setVerdiForDelPeriode(2, Periode(2.oktober(2023), 2.oktober(2023)))
+                .setVerdiForDelPeriode(2, Periode(3.oktober(2023), 3.oktober(2023)))
+                .setVerdiForDelPeriode(1, Periode(4.oktober(2023), 4.oktober(2023)))
+        kontrollerAntallBarn(perioderMedAntallBarn)
+
+        val perioderMedDagsatsOgAntallBarn =
+            perioderMedDagsats.kombiner(perioderMedAntallBarn, DagsatsOgAntallBarn::kombinerDagsatsOgAntallBarn)
+        perioderMedDagsatsOgAntallBarn.perioder().size shouldBe 4
+
+        kontrollerDagsats(perioderMedDagsatsOgAntallBarn.splitt(DagsatsOgAntallBarn::trekkUtDagsats))
+        kontrollerAntallBarn(perioderMedDagsatsOgAntallBarn.splitt(DagsatsOgAntallBarn::trekkUtAntallBarn))
+    }
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/arena/felles/PeriodeMedVerdierKombinasjonTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/arena/felles/PeriodeMedVerdierKombinasjonTest.kt
@@ -1,0 +1,89 @@
+package no.nav.tiltakspenger.arena.felles
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class PeriodeMedVerdierKombinasjonTest {
+
+    data class UtfallOgDagsatsOgAntallBarn(
+        val utfall: Utfall,
+        val dagsats: Long,
+        val antallBarn: Int,
+    ) {
+        companion object {
+            fun kombiner(
+                dto: PeriodeMedVerdierAvUlikTypeTest.DagsatsOgAntallBarn,
+                utfall: Utfall,
+            ): UtfallOgDagsatsOgAntallBarn =
+                UtfallOgDagsatsOgAntallBarn(utfall = utfall, dagsats = dto.dagsats, antallBarn = dto.antallBarn)
+        }
+    }
+
+    @Test
+    fun `eksempel på hvordan vi kan kombinere utfall og detaljer i en vedtaksperiode`() {
+        val aap =
+            PeriodeMedVerdier(
+                Utfall.OPPFYLT,
+                Periode(1.oktober(2023), 10.oktober(2023)),
+            )
+                .setVerdiForDelPeriode(Utfall.IKKE_OPPFYLT, Periode(6.oktober(2023), 10.oktober(2023)))
+
+        val fengsel =
+            PeriodeMedVerdier(
+                Utfall.OPPFYLT,
+                Periode(1.oktober(2023), 10.oktober(2023)),
+            )
+                .setVerdiForDelPeriode(Utfall.IKKE_OPPFYLT, Periode(1.oktober(2023), 2.oktober(2023)))
+
+        val jobbsjansen =
+            PeriodeMedVerdier(
+                Utfall.OPPFYLT,
+                Periode(1.oktober(2023), 10.oktober(2023)),
+            )
+                .setVerdiForDelPeriode(Utfall.IKKE_OPPFYLT, Periode(5.oktober(2023), 7.oktober(2023)))
+
+        val dagpenger =
+            PeriodeMedVerdier(
+                Utfall.OPPFYLT,
+                Periode(1.oktober(2023), 10.oktober(2023)),
+            )
+
+        val alleVilkår = listOf(aap, dagpenger, fengsel, jobbsjansen)
+        val innvilgetPerioder: PeriodeMedVerdier<Utfall> =
+            PeriodeMedVerdier.kombinerLikePerioderMedSammeTypeVerdier(alleVilkår, ::kombinerToUfall)
+
+        val perioderMedDagsats =
+            PeriodeMedVerdier(
+                250L,
+                Periode(1.oktober(2023), 10.oktober(2023)),
+            )
+                .setVerdiForDelPeriode(300L, Periode(7.oktober(2023), 10.oktober(2023)))
+
+        val perioderMedAntallBarn =
+            PeriodeMedVerdier(
+                1,
+                Periode(1.oktober(2023), 10.oktober(2023)),
+            )
+
+        val perioderMedDagsatsOgAntallBarn =
+            perioderMedDagsats.kombiner(
+                perioderMedAntallBarn,
+                PeriodeMedVerdierAvUlikTypeTest.DagsatsOgAntallBarn::kombinerDagsatsOgAntallBarn,
+            )
+
+        val totaleVedtaksPerioder: PeriodeMedVerdier<UtfallOgDagsatsOgAntallBarn> =
+            perioderMedDagsatsOgAntallBarn.kombiner(innvilgetPerioder, UtfallOgDagsatsOgAntallBarn::kombiner)
+
+        totaleVedtaksPerioder.perioder().size shouldBe 4
+    }
+
+    private fun kombinerToUfall(en: Utfall, to: Utfall): Utfall {
+        if (en == Utfall.KREVER_MANUELL_VURDERING || to == Utfall.KREVER_MANUELL_VURDERING) {
+            return Utfall.KREVER_MANUELL_VURDERING
+        }
+        if (en == Utfall.IKKE_OPPFYLT || to == Utfall.IKKE_OPPFYLT) {
+            return Utfall.IKKE_OPPFYLT
+        }
+        return Utfall.OPPFYLT
+    }
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/arena/repository/ArenaSakDTOTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/arena/repository/ArenaSakDTOTest.kt
@@ -11,8 +11,8 @@ class ArenaSakDTOTest {
         lopenrSak = 11,
         status = ArenaSakStatus.AKTIV,
         ytelsestype = ArenaYtelse.INDIV,
-        vedtak = listOf(
-            ArenaVedtakDTO(
+        tiltakspengerVedtak = listOf(
+            ArenaTiltakspengerVedtakDTO(
                 vedtakType = ArenaVedtakType.O,
                 uttaksgrad = 100,
                 fomVedtaksperiode = LocalDate.of(2023, 11, 11),
@@ -28,9 +28,8 @@ class ArenaSakDTOTest {
                 antallDager = 5.0,
                 opprinneligTomVedtaksperiode = LocalDate.of(2023, 11, 11),
                 relatertTiltak = "Tiltak",
-                antallBarn = 0,
             ),
-            ArenaVedtakDTO(
+            ArenaTiltakspengerVedtakDTO(
                 vedtakType = ArenaVedtakType.O,
                 uttaksgrad = 100,
                 fomVedtaksperiode = LocalDate.of(2023, 11, 14),
@@ -46,9 +45,8 @@ class ArenaSakDTOTest {
                 antallDager = 5.0,
                 opprinneligTomVedtaksperiode = LocalDate.of(2023, 11, 11),
                 relatertTiltak = "Tiltak",
-                antallBarn = 0,
             ),
-            ArenaVedtakDTO(
+            ArenaTiltakspengerVedtakDTO(
                 vedtakType = ArenaVedtakType.O,
                 uttaksgrad = 100,
                 fomVedtaksperiode = LocalDate.of(2023, 11, 7),
@@ -64,9 +62,9 @@ class ArenaSakDTOTest {
                 antallDager = 5.0,
                 opprinneligTomVedtaksperiode = LocalDate.of(2023, 11, 11),
                 relatertTiltak = "Tiltak",
-                antallBarn = 0,
             ),
         ),
+        barnetilleggVedtak = emptyList(),
     )
 
     private val sakMedVedtakSomAlleHarSluttDato = ArenaSakDTO(
@@ -74,8 +72,8 @@ class ArenaSakDTOTest {
         lopenrSak = 11,
         status = ArenaSakStatus.AKTIV,
         ytelsestype = ArenaYtelse.INDIV,
-        vedtak = listOf(
-            ArenaVedtakDTO(
+        tiltakspengerVedtak = listOf(
+            ArenaTiltakspengerVedtakDTO(
                 vedtakType = ArenaVedtakType.O,
                 uttaksgrad = 100,
                 fomVedtaksperiode = LocalDate.of(2023, 11, 11),
@@ -91,9 +89,8 @@ class ArenaSakDTOTest {
                 antallDager = 5.0,
                 opprinneligTomVedtaksperiode = LocalDate.of(2023, 11, 11),
                 relatertTiltak = "Tiltak",
-                antallBarn = 0,
             ),
-            ArenaVedtakDTO(
+            ArenaTiltakspengerVedtakDTO(
                 vedtakType = ArenaVedtakType.O,
                 uttaksgrad = 100,
                 fomVedtaksperiode = LocalDate.of(2023, 11, 14),
@@ -109,9 +106,8 @@ class ArenaSakDTOTest {
                 antallDager = 5.0,
                 opprinneligTomVedtaksperiode = LocalDate.of(2023, 11, 11),
                 relatertTiltak = "Tiltak",
-                antallBarn = 0,
             ),
-            ArenaVedtakDTO(
+            ArenaTiltakspengerVedtakDTO(
                 vedtakType = ArenaVedtakType.O,
                 uttaksgrad = 100,
                 fomVedtaksperiode = LocalDate.of(2023, 11, 7),
@@ -127,9 +123,9 @@ class ArenaSakDTOTest {
                 antallDager = 5.0,
                 opprinneligTomVedtaksperiode = LocalDate.of(2023, 11, 11),
                 relatertTiltak = "Tiltak",
-                antallBarn = 0,
             ),
         ),
+        barnetilleggVedtak = emptyList(),
     )
 
     private val sakMedVedtakHvorEttErÅpent = ArenaSakDTO(
@@ -137,8 +133,8 @@ class ArenaSakDTOTest {
         lopenrSak = 11,
         status = ArenaSakStatus.AKTIV,
         ytelsestype = ArenaYtelse.INDIV,
-        vedtak = listOf(
-            ArenaVedtakDTO(
+        tiltakspengerVedtak = listOf(
+            ArenaTiltakspengerVedtakDTO(
                 vedtakType = ArenaVedtakType.O,
                 uttaksgrad = 100,
                 fomVedtaksperiode = LocalDate.of(2023, 11, 11),
@@ -154,9 +150,8 @@ class ArenaSakDTOTest {
                 antallDager = 5.0,
                 opprinneligTomVedtaksperiode = LocalDate.of(2023, 11, 11),
                 relatertTiltak = "Tiltak",
-                antallBarn = 0,
             ),
-            ArenaVedtakDTO(
+            ArenaTiltakspengerVedtakDTO(
                 vedtakType = ArenaVedtakType.O,
                 uttaksgrad = 100,
                 fomVedtaksperiode = LocalDate.of(2023, 11, 14),
@@ -172,9 +167,8 @@ class ArenaSakDTOTest {
                 antallDager = 5.0,
                 opprinneligTomVedtaksperiode = LocalDate.of(2023, 11, 11),
                 relatertTiltak = "Tiltak",
-                antallBarn = 0,
             ),
-            ArenaVedtakDTO(
+            ArenaTiltakspengerVedtakDTO(
                 vedtakType = ArenaVedtakType.O,
                 uttaksgrad = 100,
                 fomVedtaksperiode = LocalDate.of(2023, 11, 7),
@@ -190,9 +184,9 @@ class ArenaSakDTOTest {
                 antallDager = 5.0,
                 opprinneligTomVedtaksperiode = LocalDate.of(2023, 11, 11),
                 relatertTiltak = "Tiltak",
-                antallBarn = 0,
             ),
         ),
+        barnetilleggVedtak = emptyList(),
     )
 
     private val sakUtenVedtak = ArenaSakDTO(
@@ -200,22 +194,23 @@ class ArenaSakDTOTest {
         lopenrSak = 11,
         status = ArenaSakStatus.AKTIV,
         ytelsestype = ArenaYtelse.INDIV,
-        vedtak = emptyList(),
+        tiltakspengerVedtak = emptyList(),
+        barnetilleggVedtak = emptyList(),
     )
 
     @Test
     fun `harVedtakMedÅpenPeriode skal fungere for sak med vedtak som alle har sluttdato`() {
-        sakMedVedtakSomAlleHarSluttDato.harVedtakMedÅpenPeriode() shouldBe false
+        sakMedVedtakSomAlleHarSluttDato.harTiltakspengerVedtakMedÅpenPeriode() shouldBe false
     }
 
     @Test
     fun `harVedtakMedÅpenPeriode skal fungere for sak med vedtak hvor ett har åpen sluttdato`() {
-        sakMedVedtakHvorEttErÅpent.harVedtakMedÅpenPeriode() shouldBe true
+        sakMedVedtakHvorEttErÅpent.harTiltakspengerVedtakMedÅpenPeriode() shouldBe true
     }
 
     @Test
     fun `harVedtakMedÅpenPeriode skal fungere for sak uten vedtak`() {
-        sakUtenVedtak.harVedtakMedÅpenPeriode() shouldBe false
+        sakUtenVedtak.harTiltakspengerVedtakMedÅpenPeriode() shouldBe false
     }
 
     @Test
@@ -241,24 +236,5 @@ class ArenaSakDTOTest {
             fom = LocalDate.of(2023, 11, 20),
             tom = LocalDate.of(2023, 11, 29),
         ).size shouldBe 1
-    }
-
-    @Test
-    fun `førsteFomVedtaksperiodeIsBefore skal fungere også når vedtak ikke er i rekkefølge`() {
-        sakHvorVedtakIkkeErIRekkefølge.førsteFomVedtaksperiodeIsBeforeOrEqualTo(
-            LocalDate.of(2023, 11, 11),
-        ) shouldBe true
-        sakHvorVedtakIkkeErIRekkefølge.førsteFomVedtaksperiodeIsBeforeOrEqualTo(
-            LocalDate.of(2023, 11, 8),
-        ) shouldBe true
-        sakHvorVedtakIkkeErIRekkefølge.førsteFomVedtaksperiodeIsBeforeOrEqualTo(
-            LocalDate.of(2023, 11, 15),
-        ) shouldBe true
-        sakHvorVedtakIkkeErIRekkefølge.førsteFomVedtaksperiodeIsBeforeOrEqualTo(
-            LocalDate.of(2023, 11, 6),
-        ) shouldBe false
-        sakHvorVedtakIkkeErIRekkefølge.førsteFomVedtaksperiodeIsBeforeOrEqualTo(
-            LocalDate.of(2023, 11, 7),
-        ) shouldBe true
     }
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/arena/repository/ArenaTiltakspengerVedtakDTOTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/arena/repository/ArenaTiltakspengerVedtakDTOTest.kt
@@ -4,9 +4,9 @@ import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
-class ArenaVedtakDTOTest {
+class ArenaTiltakspengerVedtakDTOTest {
 
-    private val vanligVedtak = ArenaVedtakDTO(
+    private val vanligVedtak = ArenaTiltakspengerVedtakDTO(
         vedtakType = ArenaVedtakType.O,
         uttaksgrad = 100,
         fomVedtaksperiode = LocalDate.of(2023, 11, 14),
@@ -22,10 +22,9 @@ class ArenaVedtakDTOTest {
         antallDager = 5.0,
         opprinneligTomVedtaksperiode = LocalDate.of(2023, 11, 11),
         relatertTiltak = "Tiltak",
-        antallBarn = 0,
     )
 
-    private val vedtakMedÅpenSluttdato = ArenaVedtakDTO(
+    private val vedtakMedÅpenSluttdato = ArenaTiltakspengerVedtakDTO(
         vedtakType = ArenaVedtakType.O,
         uttaksgrad = 100,
         fomVedtaksperiode = LocalDate.of(2023, 11, 14),
@@ -41,10 +40,9 @@ class ArenaVedtakDTOTest {
         antallDager = 5.0,
         opprinneligTomVedtaksperiode = LocalDate.of(2023, 11, 11),
         relatertTiltak = "Tiltak",
-        antallBarn = 0,
     )
 
-    private val vedtakEngangsutbetaling = ArenaVedtakDTO(
+    private val vedtakEngangsutbetaling = ArenaTiltakspengerVedtakDTO(
         vedtakType = ArenaVedtakType.O,
         uttaksgrad = 100,
         fomVedtaksperiode = LocalDate.of(2023, 11, 14),
@@ -60,7 +58,6 @@ class ArenaVedtakDTOTest {
         antallDager = 5.0,
         opprinneligTomVedtaksperiode = LocalDate.of(2023, 11, 11),
         relatertTiltak = "Tiltak",
-        antallBarn = 0,
     )
 
     @Test


### PR DESCRIPTION
## Beskrivelse
Jeg har lagtet kode for å hente ut barnetillegg-vedtak fra DB i tillegg til tiltakspenger-vedtakene jeg allerede hentet ut. Jeg har også dratt inn koden jeg opprinnelig skrev i tiltakspenger-vedtak for periodisering, og bruker denne for å merge tiltakspenger-vedtak med barnetillegg-vedtak for å få samlede vedtaksperioder. 

## Kommentarer
Koden jeg innfører er ikke i bruk i prod (jeg sjekker på miljø), og er ikke i bruk i R&R-flyten. Jeg har eksponert en REST-tjeneste for at jeg selv skal kunne teste. Den bør dermed være ganske ufarlig å merge inn.

## Visuelle endringer:
Ingen
